### PR TITLE
WIP: df patched upgrade to 2024-03-21

### DIFF
--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -2368,7 +2368,7 @@ impl DistinctOn {
 
 /// Aggregates its input based on a set of grouping and aggregate
 /// expressions (e.g. SUM).
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 // mark non_exhaustive to encourage use of try_new/new()
 #[non_exhaustive]
 pub struct Aggregate {

--- a/datafusion/substrait/src/serializer.rs
+++ b/datafusion/substrait/src/serializer.rs
@@ -27,10 +27,14 @@ use substrait::proto::Plan;
 use std::fs::OpenOptions;
 use std::io::{Read, Write};
 
-#[allow(clippy::suspicious_open_options)]
+#[allow(clippy::nonsensical_open_options)]
 pub async fn serialize(sql: &str, ctx: &SessionContext, path: &str) -> Result<()> {
     let protobuf_out = serialize_bytes(sql, ctx).await;
-    let mut file = OpenOptions::new().create(true).write(true).open(path)?;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(path)?;
     file.write_all(&protobuf_out?)?;
     Ok(())
 }


### PR DESCRIPTION
⚠️ **WIP: will not be merged.** ⚠️

## What's in this branch:

When testing against iox, we have been finding patches needed in DF. This is a branch for datafusion through EOD 2024-03-05, and then layering on patches needed.

1. Starting at datafusion main branch commit from EOD 2024-03-21 (date based on timezone 😅 ):
     ```
     commit f5dd01b75b2ad9d97b5a20967600f1aa673652c1
     
     Author: Huaijin <haohuaijin@gmail.com>
     Date:   Fri Mar 22 10:51:33 2024 +0800
     
         perf: improve to_field performance (#9722)
     ```

1. Then we add the new patch, across two commits listed in chronological order:
     ```
     commit 3c9505cd8e934cadfb7434699b62f90aa3456077
     Author: wiedld <dlw405@gmail.com>
     Date:   Wed Mar 27 19:30:33 2024 -0700
     
         refactor: remove the IdArray ordered idx, since the idx ordering does not always stay in sync with the updated TreeNode traversal
     
     commit e82114865315c3f9610ef595e2964411bcc122fb
     Author: wiedld <dlw405@gmail.com>
     Date:   Thu Mar 28 12:06:39 2024 -0700
     
         refactor: use the only reproducible key (expr_identifer) for expr_set, while keeping the (stack-popped) symbol used for alias.
     ```
     * reason for this patch is [detailed here](https://github.com/influxdata/influxdb_iox/pull/10463#issuecomment-2024334683).

1. Then a single commit to fix for clippy.

